### PR TITLE
feat: add dev-only logger

### DIFF
--- a/src/context/userContext.jsx
+++ b/src/context/userContext.jsx
@@ -1,4 +1,5 @@
 import { createContext, useState, useContext, useEffect } from 'react';
+import { logger } from '../utils/logger';
 
 export const UserContext = createContext();
 
@@ -13,18 +14,18 @@ export const UserProvider = ({ children }) => {
     localStorage.setItem('currentUser', JSON.stringify(user));
   }, [user]);
 
-  useEffect(() => {
-    localStorage.setItem('resultsList', JSON.stringify(resultsList));
-    console.log("Updated Results List in Context:", resultsList);
-  }, [resultsList]);
+    useEffect(() => {
+      localStorage.setItem('resultsList', JSON.stringify(resultsList));
+      logger('Updated Results List in Context:', resultsList);
+    }, [resultsList]);
 
-  const addResult = (result) => {
-    setResultsList(prevResults => {
-      const updatedResults = [...prevResults, { ...result, id: prevResults.length + 1, name: `Mueble ${prevResults.length + 1}` }];
-      console.log("Adding Result:", result);
-      return updatedResults;
-    });
-  };
+    const addResult = (result) => {
+      setResultsList(prevResults => {
+        const updatedResults = [...prevResults, { ...result, id: prevResults.length + 1, name: `Mueble ${prevResults.length + 1}` }];
+        logger('Adding Result:', result);
+        return updatedResults;
+      });
+    };
 
   const updateResultName = (id, newName) => {
     setResultsList(prevResults => prevResults.map(result => result.id === id ? { ...result, name: newName } : result));

--- a/src/pages/CalculatorPage.jsx
+++ b/src/pages/CalculatorPage.jsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import measurements from '../components/data/measurements.json';
 import './CalculatorPage.css';
 import { useUserContext } from '../hooks/useUserContext';
+import { logger } from '../utils/logger';
 
 const CalculatorPage = () => {
   const [width, setWidth] = useState(1000);
@@ -60,7 +61,7 @@ const CalculatorPage = () => {
     };
 
     setResult(newResult);
-    console.log("Adding Result:", newResult);
+    logger('Adding Result:', newResult);
     addResult(newResult);
   };
 

--- a/src/pages/ListPage.jsx
+++ b/src/pages/ListPage.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useUserContext } from '../hooks/useUserContext';
+import { logger } from '../utils/logger';
 import './ListPage.css';
 
 const ListPage = () => {
@@ -8,7 +9,7 @@ const ListPage = () => {
   const [newName, setNewName] = useState('');
 
   useEffect(() => {
-    console.log("Results List in ListPage:", resultsList);
+    logger('Results List in ListPage:', resultsList);
   }, [resultsList]);
 
   const handleRename = (id) => {

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -1,0 +1,7 @@
+export const logger = (...args) => {
+  if (import.meta.env.DEV) {
+    // eslint-disable-next-line no-console
+    console.log(...args);
+  }
+};
+


### PR DESCRIPTION
## Summary
- use dev-only logger for internal logging
- centralize logging via new logger utility

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ae2db46f6c8323837127aa42801566