### PR TITLE
Replace direct navigation with react-router links

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,5 +1,5 @@
 import React, { useContext, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, Link } from 'react-router-dom';
 import { UserContext } from '../context/userContext';
 import './Header.css';
 
@@ -27,13 +27,13 @@ export const Header = () => {
             ☰
           </button>
           <ul className={menuActive ? 'active' : ''}>
-            <li><a href="/">Inicio</a></li>
-            <li><a href="/calculator">Calculadora</a></li>
-            <li><a href="/list">Mis Proyectos</a></li>
+            <li><Link to="/">Inicio</Link></li>
+            <li><Link to="/calculator">Calculadora</Link></li>
+            <li><Link to="/list">Mis Proyectos</Link></li>
             {!user ? (
               <>
-                <li><a href="/register">Registrarse</a></li>
-                <li><a href="/login">Iniciar Sesión</a></li>
+                <li><Link to="/register">Registrarse</Link></li>
+                <li><Link to="/login">Iniciar Sesión</Link></li>
               </>
             ) : (
               <li>

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,6 +1,9 @@
 import "./Home.css"
+import { useNavigate } from 'react-router-dom';
 
 const Home = () => {
+  const navigate = useNavigate();
+
   return (
     <div className="home-content">
       <section className="home-intro">
@@ -15,11 +18,11 @@ const Home = () => {
           <li>Fácil de usar</li>
           <li>Acceso desde cualquier dispositivo</li>
         </ul>
-      </section>
-      <section className="home-actions">
-        <button onClick={() => window.location.href='/calculator'}>Empezar a Calcular</button>
-        <button onClick={() => window.location.href='/register'}>Registrarse</button>
-      </section>
+        </section>
+        <section className="home-actions">
+          <button onClick={() => navigate('/calculator')}>Empezar a Calcular</button>
+          <button onClick={() => navigate('/register')}>Registrarse</button>
+        </section>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Use `useNavigate` for Home page buttons instead of `window.location.href`
- Replace `<a>` tags in the header with React Router `<Link>` components

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68ae2dacf1308323bc9eb9f0dacf38f8