### PR TITLE
refactor: remove redundant user provider wrapping

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -3,13 +3,9 @@ import ReactDOM from 'react-dom/client'
 import './index.css'
 import { RouterProvider } from 'react-router-dom'
 import { router } from './routes/Routes'
-import { UserProvider } from './context/userContext'
-
 
 ReactDOM.createRoot(document.getElementById('root')).render(
     <React.StrictMode>
-    <UserProvider>
     <RouterProvider router={router} />
-    </UserProvider>
     </React.StrictMode>
 )


### PR DESCRIPTION
## Summary
- remove UserProvider import and wrapper from main entry point

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: ESLint couldn't find a configuration file)


------
https://chatgpt.com/codex/tasks/task_e_68ae2d9a450c8323ac943591f3438247