### PR TITLE
refactor: consolidate useUserContext

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,7 @@ drawer_calculator/
 │   │   ├── Footer.jsx
 │   │   └── ...
 │   ├── context/
-│   │   ├── UserContext.jsx
-│   ├── hooks/
-│   │   ├── useUserContext.jsx
+│   │   ├── userContext.jsx
 │   ├── pages/
 │   │   ├── Home.jsx
 │   │   ├── LoginPage.jsx

--- a/src/components/ProtectedRoutes/Protected.jsx
+++ b/src/components/ProtectedRoutes/Protected.jsx
@@ -1,5 +1,5 @@
 import { Navigate } from 'react-router-dom';
-import { useUserContext } from '../../hooks/useUserContext';
+import { useUserContext } from '../../context/userContext';
 
 const ProtectedRoute = ({ children }) => {
   const { user } = useUserContext();

--- a/src/hooks/useUserContext.jsx
+++ b/src/hooks/useUserContext.jsx
@@ -1,7 +1,0 @@
-import { useContext } from 'react';
-import { UserContext } from '../context/userContext';
-
-
-export const useUserContext = () => {
-  return useContext(UserContext);
-};

--- a/src/pages/CalculatorPage.jsx
+++ b/src/pages/CalculatorPage.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import measurements from '../components/data/measurements.json';
 import './CalculatorPage.css';
-import { useUserContext } from '../hooks/useUserContext';
+import { useUserContext } from '../context/userContext';
 import { logger } from '../utils/logger';
 
 const CalculatorPage = () => {

--- a/src/pages/ListPage.jsx
+++ b/src/pages/ListPage.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { useUserContext } from '../hooks/useUserContext';
+import { useUserContext } from '../context/userContext';
 import { logger } from '../utils/logger';
 import './ListPage.css';
 

--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useUserContext } from '../hooks/useUserContext';
+import { useUserContext } from '../context/userContext';
 
 const LoginPage = () => {
   const [username, setUsername] = useState('');


### PR DESCRIPTION
## Summary
- remove redundant `useUserContext` hook file
- export `useUserContext` directly from `context/userContext`
- update pages and components to import from context
- sync README file structure with new layout

## Testing
- ⚠️ `npm test` (Missing script: "test")
- ⚠️ `npm run lint` (ESLint couldn't find a configuration file)


------
https://chatgpt.com/codex/tasks/task_e_68ae31d1259c8323b8f56e3a5b128be4