### PR TITLE
Refactor calculator into modular components using MUI

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,10 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.23.1"
+    "react-router-dom": "^6.23.1",
+    "@emotion/react": "^11.11.1",
+    "@emotion/styled": "^11.11.0",
+    "@mui/material": "^5.15.14"
   },
   "devDependencies": {
     "@types/react": "^18.2.66",

--- a/src/components/calculator/DrawerSettings.jsx
+++ b/src/components/calculator/DrawerSettings.jsx
@@ -1,0 +1,113 @@
+import React from 'react';
+import {
+  FormControl,
+  Grid,
+  InputLabel,
+  MenuItem,
+  Select,
+  TextField,
+  Typography,
+} from '@mui/material';
+
+const DrawerSettings = ({
+  type,
+  setType,
+  guideLength,
+  setGuideLength,
+  numDrawers,
+  setNumDrawers,
+  bottomThickness,
+  setBottomThickness,
+  drawerThickness,
+  setDrawerThickness,
+  drawerHeight,
+  setDrawerHeight,
+  manualDrawerHeight,
+  setManualDrawerHeight,
+}) => (
+  <div className="section">
+    <Typography variant="h3">Cajones</Typography>
+    <Grid container spacing={2} className="form-group">
+      <Grid item xs={12} sm={6} md={4}>
+        <FormControl fullWidth>
+          <InputLabel>Tipo</InputLabel>
+          <Select value={type} label="Tipo" onChange={(e) => setType(e.target.value)}>
+            <MenuItem value="tandem16">Tandem 16</MenuItem>
+            <MenuItem value="tandem19">Tandem 19</MenuItem>
+          </Select>
+        </FormControl>
+      </Grid>
+      <Grid item xs={12} sm={6} md={4}>
+        <FormControl fullWidth>
+          <InputLabel>Largo de Guía</InputLabel>
+          <Select value={guideLength} label="Largo de Guía" onChange={(e) => setGuideLength(e.target.value)}>
+            <MenuItem value="auto">Auto</MenuItem>
+            {[...Array(11)].map((_, i) => {
+              const length = 250 + i * 50;
+              return (
+                <MenuItem key={length} value={length}>{`${length} mm`}</MenuItem>
+              );
+            })}
+          </Select>
+        </FormControl>
+      </Grid>
+      <Grid item xs={12} sm={6} md={4}>
+        <TextField
+          label="Número de cajones"
+          type="number"
+          value={numDrawers}
+          onChange={(e) => setNumDrawers(e.target.value)}
+          fullWidth
+          inputProps={{ min: 1 }}
+        />
+      </Grid>
+      <Grid item xs={12} sm={6} md={4}>
+        <TextField
+          label="Grueso del fondo del cajón en mm"
+          type="number"
+          value={bottomThickness}
+          onChange={(e) => setBottomThickness(e.target.value)}
+          fullWidth
+        />
+      </Grid>
+      <Grid item xs={12} sm={6} md={4}>
+        <FormControl fullWidth>
+          <InputLabel>Grueso del cajón en mm</InputLabel>
+          <Select
+            value={drawerThickness}
+            label="Grueso del cajón en mm"
+            onChange={(e) => setDrawerThickness(e.target.value)}
+          >
+            <MenuItem value="16">16 mm</MenuItem>
+            <MenuItem value="19">19 mm</MenuItem>
+          </Select>
+        </FormControl>
+      </Grid>
+      <Grid item xs={12} sm={6} md={4}>
+        <FormControl fullWidth>
+          <InputLabel>Altura lateral cajón</InputLabel>
+          <Select
+            value={drawerHeight}
+            label="Altura lateral cajón"
+            onChange={(e) => setDrawerHeight(e.target.value)}
+          >
+            <MenuItem value="auto">Auto</MenuItem>
+            <MenuItem value="manual">Manual</MenuItem>
+          </Select>
+        </FormControl>
+        {drawerHeight === 'manual' && (
+          <TextField
+            sx={{ mt: 2 }}
+            type="number"
+            label="Altura manual"
+            value={manualDrawerHeight}
+            onChange={(e) => setManualDrawerHeight(e.target.value)}
+            fullWidth
+          />
+        )}
+      </Grid>
+    </Grid>
+  </div>
+);
+
+export default DrawerSettings;

--- a/src/components/calculator/MeasurementForm.jsx
+++ b/src/components/calculator/MeasurementForm.jsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { Grid, TextField, Typography } from '@mui/material';
+
+const MeasurementForm = ({
+  width,
+  height,
+  depth,
+  sideThickness,
+  traverseThickness,
+  setWidth,
+  setHeight,
+  setDepth,
+  setSideThickness,
+  setTraverseThickness,
+}) => (
+  <div className="section">
+    <Typography variant="h3">Mueble</Typography>
+    <Grid container spacing={2} className="form-group">
+      <Grid item xs={12} sm={6} md={4}>
+        <TextField
+          label="Ancho interior mueble en mm"
+          type="number"
+          value={width}
+          onChange={(e) => setWidth(e.target.value)}
+          fullWidth
+        />
+      </Grid>
+      <Grid item xs={12} sm={6} md={4}>
+        <TextField
+          label="Alto interior mueble en mm"
+          type="number"
+          value={height}
+          onChange={(e) => setHeight(e.target.value)}
+          fullWidth
+        />
+      </Grid>
+      <Grid item xs={12} sm={6} md={4}>
+        <TextField
+          label="Profundidad del mueble en mm"
+          type="number"
+          value={depth}
+          onChange={(e) => setDepth(e.target.value)}
+          fullWidth
+        />
+      </Grid>
+      <Grid item xs={12} sm={6} md={4}>
+        <TextField
+          label="Grueso de los laterales (montante) en mm"
+          type="number"
+          value={sideThickness}
+          onChange={(e) => setSideThickness(e.target.value)}
+          fullWidth
+        />
+      </Grid>
+      <Grid item xs={12} sm={6} md={4}>
+        <TextField
+          label="Grueso de los travesaños en mm"
+          type="number"
+          value={traverseThickness}
+          onChange={(e) => setTraverseThickness(e.target.value)}
+          fullWidth
+        />
+      </Grid>
+    </Grid>
+  </div>
+);
+
+export default MeasurementForm;

--- a/src/components/calculator/ResultList.jsx
+++ b/src/components/calculator/ResultList.jsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { List, ListItem, ListItemText, Typography } from '@mui/material';
+
+const ResultList = ({ result, numDrawers }) => (
+  <div className="calculator-result">
+    <Typography variant="h3">Resultados:</Typography>
+    {numDrawers < 3 ? (
+      <List>
+        <ListItem>
+          <ListItemText
+            primary="Travesaños"
+            secondary={`${result.travesanos.total} de ${result.travesanos.length} x ${result.travesanosAltura} x ${result.travesanos.thickness} mm`}
+          />
+        </ListItem>
+        <ListItem>
+          <ListItemText
+            primary="Laterales"
+            secondary={`${result.laterales.total} de ${result.laterales.length} x ${result.drawerHeight} x ${result.laterales.thickness} mm`}
+          />
+        </ListItem>
+        <ListItem>
+          <ListItemText
+            primary="Fondos"
+            secondary={`${result.fondos.total} de ${result.fondos.length} x ${result.fondos.width} x ${result.fondos.thickness} mm`}
+          />
+        </ListItem>
+      </List>
+    ) : (
+      <List>
+        <ListItem>
+          <ListItemText
+            primary="Travesaños superior/inferior"
+            secondary={`4 de ${result.travesanos.length} x ${result.travesanosAltura.topBottomTravesanosAltura} x ${result.travesanos.thickness} mm`}
+          />
+        </ListItem>
+        <ListItem>
+          <ListItemText
+            primary="Laterales superior/inferior"
+            secondary={`4 de ${result.laterales.length} x ${result.drawerHeight.topBottomHeight} x ${result.laterales.thickness} mm`}
+          />
+        </ListItem>
+        <ListItem>
+          <ListItemText
+            primary="Travesaños centrales"
+            secondary={`${result.travesanos.total - 4} de ${result.travesanos.length} x ${result.travesanosAltura.centralTravesanosAltura} x ${result.travesanos.thickness} mm`}
+          />
+        </ListItem>
+        <ListItem>
+          <ListItemText
+            primary="Laterales centrales"
+            secondary={`${result.laterales.total - 4} de ${result.laterales.length} x ${result.drawerHeight.centralHeight} x ${result.laterales.thickness} mm`}
+          />
+        </ListItem>
+        <ListItem>
+          <ListItemText
+            primary="Fondos"
+            secondary={`${result.fondos.total} de ${result.fondos.length} x ${result.fondos.width} x ${result.fondos.thickness} mm`}
+          />
+        </ListItem>
+      </List>
+    )}
+  </div>
+);
+
+export default ResultList;

--- a/src/components/calculator/index.js
+++ b/src/components/calculator/index.js
@@ -1,0 +1,3 @@
+export { default as MeasurementForm } from './MeasurementForm.jsx';
+export { default as DrawerSettings } from './DrawerSettings.jsx';
+export { default as ResultList } from './ResultList.jsx';

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,2 +1,3 @@
 export * from "./Header.jsx";
 export * from "./Footer.jsx";
+export * from "./calculator";

--- a/src/pages/CalculatorPage.jsx
+++ b/src/pages/CalculatorPage.jsx
@@ -3,6 +3,16 @@ import measurements from '../components/data/measurements.json';
 import './CalculatorPage.css';
 import { useUserContext } from '../hooks/useUserContext';
 import { logger } from '../utils/logger';
+import {
+  calculateTravesanos,
+  calculateLaterales,
+  calculateFondos,
+  calculateAutoGuideLength,
+  calculateAutoDrawerHeight,
+  calculateTravesanosAltura,
+} from '../utils/calculations';
+import { MeasurementForm, DrawerSettings, ResultList } from '../components/calculator';
+import { Button, Typography } from '@mui/material';
 
 const CalculatorPage = () => {
   const [width, setWidth] = useState(1000);
@@ -26,28 +36,57 @@ const CalculatorPage = () => {
       height: Math.round(parseFloat(height)),
       depth: Math.round(parseFloat(depth)),
       bottomThickness: Math.round(parseFloat(bottomThickness)),
-      numDrawers: Math.round(parseInt(numDrawers)),
+      numDrawers: Math.round(parseInt(numDrawers, 10)),
       sideThickness: Math.round(parseFloat(sideThickness)),
       traverseThickness: Math.round(parseFloat(traverseThickness)),
       drawerThickness: Math.round(parseFloat(drawerThickness)),
-      drawerHeight: drawerHeight === 'auto'
-        ? calculateAutoDrawerHeight(Math.round(parseFloat(height)), Math.round(parseInt(numDrawers)), Math.round(parseFloat(traverseThickness)))
-        : Math.round(parseFloat(manualDrawerHeight)),
+      drawerHeight:
+        drawerHeight === 'auto'
+          ? calculateAutoDrawerHeight(
+              Math.round(parseFloat(height)),
+              Math.round(parseInt(numDrawers, 10)),
+              Math.round(parseFloat(traverseThickness))
+            )
+          : Math.round(parseFloat(manualDrawerHeight)),
     };
 
     const predefinedMeasurements = measurements[type];
-    const selectedGuideLength = guideLength === 'auto'
-      ? calculateAutoGuideLength(userMeasurements.depth, predefinedMeasurements.optimalGuideLength)
-      : Math.round(parseInt(guideLength));
+    const selectedGuideLength =
+      guideLength === 'auto'
+        ? calculateAutoGuideLength(
+            userMeasurements.depth,
+            predefinedMeasurements.optimalGuideLength
+          )
+        : Math.round(parseInt(guideLength, 10));
 
-    const travesanos = calculateTravesanos(userMeasurements.width, predefinedMeasurements.resto, userMeasurements.numDrawers);
-    const laterales = calculateLaterales(userMeasurements.depth, userMeasurements.numDrawers, selectedGuideLength, userMeasurements.drawerHeight);
-    const fondos = calculateFondos(laterales.length, travesanos.length, drawerThickness, userMeasurements.numDrawers);
-    const travesanosAltura = calculateTravesanosAltura(userMeasurements.drawerHeight, userMeasurements.bottomThickness, userMeasurements.numDrawers);
+    const travesanos = calculateTravesanos(
+      userMeasurements.width,
+      predefinedMeasurements.resto,
+      userMeasurements.numDrawers
+    );
+    const laterales = calculateLaterales(
+      userMeasurements.depth,
+      userMeasurements.numDrawers,
+      selectedGuideLength,
+      userMeasurements.drawerHeight
+    );
+    const fondos = calculateFondos(
+      laterales.length,
+      travesanos.length,
+      drawerThickness,
+      userMeasurements.numDrawers,
+      userMeasurements.bottomThickness
+    );
+    const travesanosAltura = calculateTravesanosAltura(
+      userMeasurements.drawerHeight,
+      userMeasurements.bottomThickness,
+      userMeasurements.numDrawers
+    );
 
-    const finalDrawerHeight = typeof userMeasurements.drawerHeight === 'object'
-      ? JSON.stringify(userMeasurements.drawerHeight)
-      : userMeasurements.drawerHeight;
+    const finalDrawerHeight =
+      typeof userMeasurements.drawerHeight === 'object'
+        ? JSON.stringify(userMeasurements.drawerHeight)
+        : userMeasurements.drawerHeight;
 
     const newResult = {
       ...userMeasurements,
@@ -65,208 +104,41 @@ const CalculatorPage = () => {
     addResult(newResult);
   };
 
-  const calculateTravesanos = (width, resto, numDrawers) => {
-    const travesanoLength = Math.round(width - resto);
-    const totalTravesanos = numDrawers >= 3 ? 4 + (numDrawers - 2) * 2 : numDrawers * 2;
-    return {
-      length: travesanoLength,
-      total: totalTravesanos,
-      thickness: 16, // Por defecto o según formulario
-      height: 125 // Ejemplo, ajustar según necesidad
-    };
-  };
-
-  const calculateLaterales = (depth, numDrawers, guideLength, drawerHeight) => {
-    const lateralLength = Math.round(depth - 10);
-    const totalLaterales = numDrawers >= 3 ? 4 + (numDrawers - 2) * 2 : numDrawers * 2;
-    const effectiveLength = Math.round(Math.min(lateralLength, guideLength - 10));
-    return {
-      length: effectiveLength,
-      total: totalLaterales,
-      thickness: 16, // Por defecto o según formulario
-      height: drawerHeight
-    };
-  };
-
-  const calculateFondos = (lateralLength, travesanoLength, drawerThickness, numDrawers) => {
-    const fondoLength = Math.round(travesanoLength + drawerThickness);
-    const totalFondos = Math.round(numDrawers);
-    return {
-      length: lateralLength,
-      width: fondoLength,
-      total: totalFondos,
-      thickness: bottomThickness // Según formulario
-    };
-  };
-
-  const calculateAutoGuideLength = (depth, optimalGuideLengths) => {
-    return Math.round(optimalGuideLengths.reduce((prev, curr) => {
-      if (curr + 10 <= depth) {
-        return Math.abs(curr - depth) < Math.abs(prev - depth) ? curr : prev;
-      }
-      return prev;
-    }));
-  };
-
-  const calculateAutoDrawerHeight = (height, numDrawers, traverseThickness) => {
-    const marginSuperior = 10;
-    const alturaGuia = 34 - 15; // 34 mm de la guía - 15 mm adicionales
-    if (numDrawers === 1) {
-      return Math.round(height - marginSuperior - alturaGuia);
-    } else if (numDrawers === 2) {
-      const halfHeight = Math.round(height / 2);
-      return Math.round(halfHeight - marginSuperior - alturaGuia);
-    } else {
-      const adjustedHeight = Math.round(height + traverseThickness * 2);
-      const divisionHeight = Math.round(adjustedHeight / 3);
-      const topBottomHeight = Math.round(divisionHeight - traverseThickness);
-      const centralHeight = Math.round(divisionHeight);
-
-      return {
-        topBottomHeight: Math.round(topBottomHeight - marginSuperior - alturaGuia),
-        centralHeight: Math.round(centralHeight - marginSuperior - alturaGuia),
-      };
-    }
-  };
-
-  const calculateTravesanosAltura = (drawerHeight, bottomThickness, numDrawers) => {
-    if (numDrawers < 3) {
-      return Math.round(drawerHeight - 15 - bottomThickness);
-    } else {
-      const { topBottomHeight, centralHeight } = drawerHeight;
-      const topBottomTravesanosAltura = Math.round(topBottomHeight - 15 - bottomThickness);
-      const centralTravesanosAltura = Math.round(centralHeight - 15 - bottomThickness);
-      return {
-        topBottomTravesanosAltura,
-        centralTravesanosAltura,
-      };
-    }
-  };
-
   return (
     <div className="calculator-container">
-      <h2>Calculadora de Cajones</h2>
-      <div className="section">
-        <h3>Mueble</h3>
-        <div className="form-group">
-          <label>
-            Ancho interior mueble en mm:
-            <input type="number" value={width} onChange={(e) => setWidth(e.target.value)} />
-          </label>
-          <label>
-            Alto interior mueble en mm:
-            <input type="number" value={height} onChange={(e) => setHeight(e.target.value)} />
-          </label>
-          <label>
-            Profundidad del mueble en mm:
-            <input type="number" value={depth} onChange={(e) => setDepth(e.target.value)} />
-          </label>
-          <label>
-            Grueso de los laterales (montante) en mm:
-            <input type="number" value={sideThickness} onChange={(e) => setSideThickness(e.target.value)} />
-          </label>
-          <label>
-            Grueso de los travesaños en mm:
-            <input type="number" value={traverseThickness} onChange={(e) => setTraverseThickness(e.target.value)} />
-          </label>
-        </div>
-      </div>
-      <div className="section">
-        <h3>Cajones</h3>
-        <div className="form-group">
-          <label>
-            Tipo:
-            <select value={type} onChange={(e) => setType(e.target.value)}>
-              <option value="tandem16">Tandem 16</option>
-              <option value="tandem19">Tandem 19</option>
-            </select>
-          </label>
-          <label>
-            Largo de Guía:
-            <select value={guideLength} onChange={(e) => setGuideLength(e.target.value)}>
-              <option value="auto">Auto</option>
-              {[...Array(11)].map((_, i) => {
-                const length = 250 + i * 50;
-                return <option key={length} value={length}>{length} mm</option>;
-              })}
-            </select>
-          </label>
-          <label>
-            Número de cajones:
-            <input type="number" value={numDrawers} min="1" onChange={(e) => setNumDrawers(e.target.value)} />
-          </label>
-          <label>
-            Grueso del fondo del cajón en mm:
-            <input type="number" value={bottomThickness} onChange={(e) => setBottomThickness(e.target.value)} />
-          </label>
-          <label>
-            Grueso del cajón en mm:
-            <select value={drawerThickness} onChange={(e) => setDrawerThickness(e.target.value)}>
-              <option value="16">16 mm</option>
-              <option value="19">19 mm</option>
-            </select>
-          </label>
-          <label>
-            Altura lateral cajón:
-            <select value={drawerHeight} onChange={(e) => setDrawerHeight(e.target.value)}>
-              <option value="auto">Auto</option>
-              <option value="manual">Manual</option>
-            </select>
-            {drawerHeight === 'manual' && (
-              <input
-                type="number"
-                value={manualDrawerHeight}
-                onChange={(e) => setManualDrawerHeight(e.target.value)}
-              />
-            )}
-          </label>
-        </div>
-      </div>
-      <button onClick={handleCalculate}>Calcular</button>
-      {result && (
-        <div className="calculator-result">
-          <h3>Resultados:</h3>
-          {numDrawers < 3 ? (
-            <>
-              <div>
-                <h4>Travesaños:</h4>
-                <p>{result.travesanos.total} de {result.travesanos.length} x {result.travesanosAltura} x {result.travesanos.thickness} mm</p>
-              </div>
-              <div>
-                <h4>Laterales:</h4>
-                <p>{result.laterales.total} de {result.laterales.length} x {result.drawerHeight} x {result.laterales.thickness} mm</p>
-              </div>
-              <div>
-                <h4>Fondos:</h4>
-                <p>{result.fondos.total} de {result.fondos.length} x {result.fondos.width} x {result.fondos.thickness} mm</p>
-              </div>
-            </>
-          ) : (
-            <>
-              <div>
-                <h4>Travesaños superior/inferior:</h4>
-                <p>4 de {result.travesanos.length} x {result.travesanosAltura.topBottomTravesanosAltura} x {result.travesanos.thickness} mm</p>
-              </div>
-              <div>
-                <h4>Laterales superior/inferior:</h4>
-                <p>4 de {result.laterales.length} x {result.drawerHeight.topBottomHeight} x {result.laterales.thickness} mm</p>
-              </div>
-              <div>
-                <h4>Travesaños centrales:</h4>
-                <p>{result.travesanos.total - 4} de {result.travesanos.length} x {result.travesanosAltura.centralTravesanosAltura} x {result.travesanos.thickness} mm</p>
-              </div>
-              <div>
-                <h4>Laterales centrales:</h4>
-                <p>{result.laterales.total - 4} de {result.laterales.length} x {result.drawerHeight.centralHeight} x {result.laterales.thickness} mm</p>
-              </div>
-              <div>
-                <h4>Fondos:</h4>
-                <p>{result.fondos.total} de {result.fondos.length} x {result.fondos.width} x {result.fondos.thickness} mm</p>
-              </div>
-            </>
-          )}
-        </div>
-      )}
+      <Typography variant="h2">Calculadora de Cajones</Typography>
+      <MeasurementForm
+        width={width}
+        height={height}
+        depth={depth}
+        sideThickness={sideThickness}
+        traverseThickness={traverseThickness}
+        setWidth={setWidth}
+        setHeight={setHeight}
+        setDepth={setDepth}
+        setSideThickness={setSideThickness}
+        setTraverseThickness={setTraverseThickness}
+      />
+      <DrawerSettings
+        type={type}
+        setType={setType}
+        guideLength={guideLength}
+        setGuideLength={setGuideLength}
+        numDrawers={numDrawers}
+        setNumDrawers={setNumDrawers}
+        bottomThickness={bottomThickness}
+        setBottomThickness={setBottomThickness}
+        drawerThickness={drawerThickness}
+        setDrawerThickness={setDrawerThickness}
+        drawerHeight={drawerHeight}
+        setDrawerHeight={setDrawerHeight}
+        manualDrawerHeight={manualDrawerHeight}
+        setManualDrawerHeight={setManualDrawerHeight}
+      />
+      <Button variant="contained" onClick={handleCalculate}>
+        Calcular
+      </Button>
+      {result && <ResultList result={result} numDrawers={numDrawers} />}
     </div>
   );
 };

--- a/src/utils/calculations.js
+++ b/src/utils/calculations.js
@@ -1,0 +1,77 @@
+export const calculateTravesanos = (width, resto, numDrawers) => {
+  const travesanoLength = Math.round(width - resto);
+  const totalTravesanos = numDrawers >= 3 ? 4 + (numDrawers - 2) * 2 : numDrawers * 2;
+  return {
+    length: travesanoLength,
+    total: totalTravesanos,
+    thickness: 16, // Por defecto o según formulario
+    height: 125 // Ejemplo, ajustar según necesidad
+  };
+};
+
+export const calculateLaterales = (depth, numDrawers, guideLength, drawerHeight) => {
+  const lateralLength = Math.round(depth - 10);
+  const totalLaterales = numDrawers >= 3 ? 4 + (numDrawers - 2) * 2 : numDrawers * 2;
+  const effectiveLength = Math.round(Math.min(lateralLength, guideLength - 10));
+  return {
+    length: effectiveLength,
+    total: totalLaterales,
+    thickness: 16, // Por defecto o según formulario
+    height: drawerHeight
+  };
+};
+
+export const calculateFondos = (lateralLength, travesanoLength, drawerThickness, numDrawers, bottomThickness) => {
+  const fondoLength = Math.round(travesanoLength + drawerThickness);
+  const totalFondos = Math.round(numDrawers);
+  return {
+    length: lateralLength,
+    width: fondoLength,
+    total: totalFondos,
+    thickness: bottomThickness // Según formulario
+  };
+};
+
+export const calculateAutoGuideLength = (depth, optimalGuideLengths) => {
+  return Math.round(optimalGuideLengths.reduce((prev, curr) => {
+    if (curr + 10 <= depth) {
+      return Math.abs(curr - depth) < Math.abs(prev - depth) ? curr : prev;
+    }
+    return prev;
+  }));
+};
+
+export const calculateAutoDrawerHeight = (height, numDrawers, traverseThickness) => {
+  const marginSuperior = 10;
+  const alturaGuia = 34 - 15; // 34 mm de la guía - 15 mm adicionales
+  if (numDrawers === 1) {
+    return Math.round(height - marginSuperior - alturaGuia);
+  } else if (numDrawers === 2) {
+    const halfHeight = Math.round(height / 2);
+    return Math.round(halfHeight - marginSuperior - alturaGuia);
+  } else {
+    const adjustedHeight = Math.round(height + traverseThickness * 2);
+    const divisionHeight = Math.round(adjustedHeight / 3);
+    const topBottomHeight = Math.round(divisionHeight - traverseThickness);
+    const centralHeight = Math.round(divisionHeight);
+
+    return {
+      topBottomHeight: Math.round(topBottomHeight - marginSuperior - alturaGuia),
+      centralHeight: Math.round(centralHeight - marginSuperior - alturaGuia),
+    };
+  }
+};
+
+export const calculateTravesanosAltura = (drawerHeight, bottomThickness, numDrawers) => {
+  if (numDrawers < 3) {
+    return Math.round(drawerHeight - 15 - bottomThickness);
+  } else {
+    const { topBottomHeight, centralHeight } = drawerHeight;
+    const topBottomTravesanosAltura = Math.round(topBottomHeight - 15 - bottomThickness);
+    const centralTravesanosAltura = Math.round(centralHeight - 15 - bottomThickness);
+    return {
+      topBottomTravesanosAltura,
+      centralTravesanosAltura,
+    };
+  }
+};


### PR DESCRIPTION
## Summary
- extract calculation helpers into reusable utils
- refactor CalculatorPage to use Material UI subcomponents
- expose new calculator components and add Material UI dependencies

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68ae31ca6bd0832385a3d15c6210e9ef