### PR TITLE
feat: allow editing saved projects

### DIFF
--- a/src/pages/ListPage.jsx
+++ b/src/pages/ListPage.jsx
@@ -1,10 +1,12 @@
 import React, { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useUserContext } from '../hooks/useUserContext';
 import { logger } from '../utils/logger';
 import './ListPage.css';
 
 const ListPage = () => {
-  const { resultsList, updateResultName, removeResult, recalculateResult } = useUserContext();
+  const { resultsList, updateResultName, removeResult } = useUserContext();
+  const navigate = useNavigate();
   const [editId, setEditId] = useState(null);
   const [newName, setNewName] = useState('');
 
@@ -18,9 +20,8 @@ const ListPage = () => {
     setNewName('');
   };
 
-  const handleRecalculate = (result) => {
-    const recalculatedResult = { ...result };
-    recalculateResult(result.id, recalculatedResult);
+  const handleEdit = (result) => {
+    navigate('/calculator', { state: { result } });
   };
 
   const renderResultDetails = (result) => {
@@ -92,6 +93,7 @@ const ListPage = () => {
                 <button onClick={() => { setEditId(result.id); setNewName(result.name); }}>Renombrar</button>
               </>
             )}
+            <button onClick={() => handleEdit(result)}>Editar</button>
             <button onClick={() => removeResult(result.id)}>Eliminar</button>
             <figure>
               {renderResultDetails(result)}


### PR DESCRIPTION
## Summary
- add Edit button on project list items that routes to calculator with project state
- prefill calculator form when editing and update existing result instead of adding a new one

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68ae31fde71483238bf38d6a81147bb7