### PR TITLE
Improve Alpha Vantage rate limit handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Completa `ALPHA_VANTAGE_KEY` con tu clave cuando uses el modo Alpha Vantage.
 2. Revisa o ajusta la lista de pares en el textarea.
 3. Selecciona el timeframe y la fuente de datos.
 4. Si eliges Alpha Vantage, introduce tu API key.
-5. Pulsa **Calcular**. La app descargará cada serie de precios de forma secuencial (1.4 s entre peticiones para respetar el rate limit) y mostrará resultados.
+5. Pulsa **Calcular**. La app descargará cada serie de precios de forma secuencial (12.5 s entre peticiones para respetar el límite gratuito de Alpha Vantage) y mostrará resultados.
 
 Los cálculos del modo Demo se generan con una caminata aleatoria suave para probar la UI sin depender de la API.
 
@@ -122,7 +122,7 @@ Las pruebas unitarias se ubican junto a los módulos (`*.test.ts`).
 
 ## Troubleshooting
 
-- **Rate limit de Alpha Vantage:** aparecerá un mensaje de error. Espera unos segundos y vuelve a intentar o usa el modo Demo.
+- **Rate limit de Alpha Vantage:** el servicio gratuito permite 5 peticiones por minuto y 500 por día. Si ves un mensaje de "Alpha Vantage no devolvió datos...", espera al menos un minuto, reduce el número de pares o cambia al modo Demo.
 - **Series insuficientes:** si un par devuelve pocos datos, se mostrará "—" en sus métricas.
 - **Fallo de dependencias:** asegúrate de tener acceso al registro de npm o usa un mirror autorizado.
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,8 @@ const MODE_OPTIONS: { value: Mode; label: string }[] = [
   { value: "alphavantage", label: "Alpha Vantage" },
 ];
 
+const ALPHA_VANTAGE_DELAY_MS = 12_500;
+
 const DEFAULT_PAIRS_TEXT = DEFAULT_PAIRS.join("\n");
 
 function computeSignal(globalScore: number | null, overPct: number, underPct: number): GlobalSignal {
@@ -95,7 +97,7 @@ function App() {
         nextRows.push({ pair, rsi: null, tsi: null, score: null });
       }
       if (mode === "alphavantage" && i < pairs.length - 1) {
-        await sleep(1400);
+        await sleep(ALPHA_VANTAGE_DELAY_MS);
       }
     }
 

--- a/src/services/dataProviders.ts
+++ b/src/services/dataProviders.ts
@@ -58,10 +58,12 @@ export async function fetchClosesAlphaVantage(
   const seriesKey = extractSeriesKey(tf);
   const series = data[seriesKey] as Record<string, { "4. close": string }> | undefined;
   if (!series) {
+    const info = (data as { Information?: unknown }).Information;
     const message =
       (typeof data.Note === "string" && data.Note) ||
       (typeof data["Error Message"] === "string" && data["Error Message"]) ||
-      "Sin datos (posible rate limit)";
+      (typeof info === "string" && info) ||
+      "Alpha Vantage no devolvió datos. Suele ocurrir al superar el límite gratuito (5 peticiones por minuto y 500 al día) o cuando el par no está disponible.";
     throw new Error(message);
   }
   const entries = Object.entries(series).sort(


### PR DESCRIPTION
## Summary
- increase the Alpha Vantage delay to respect the free tier limit and document the change
- surface Alpha Vantage information messages and provide clearer fallback guidance when no data is returned

## Testing
- npm test -- --run *(fails: vitest not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e692be23ac8323b2595d3e9de39b38